### PR TITLE
add `wrong device public keys` error.

### DIFF
--- a/dist/clients/Device.js
+++ b/dist/clients/Device.js
@@ -292,7 +292,7 @@ var Device = function (_EventEmitter) {
               })(), 't0', 2);
 
             case 2:
-              _context3.next = 7;
+              _context3.next = 8;
               break;
 
             case 4:
@@ -300,8 +300,9 @@ var Device = function (_EventEmitter) {
               _context3.t1 = _context3['catch'](0);
 
               _this.disconnect(_context3.t1);
+              throw _context3.t1;
 
-            case 7:
+            case 8:
             case 'end':
               return _context3.stop();
           }

--- a/dist/lib/Handshake.js
+++ b/dist/lib/Handshake.js
@@ -202,6 +202,15 @@ var Handshake = function Handshake(cryptoManager) {
 
           case 22:
             handshakeBuffer = _context2.sent;
+
+            if (handshakeBuffer) {
+              _context2.next = 25;
+              break;
+            }
+
+            throw new Error('wrong device public keys');
+
+          case 25:
             return _context2.abrupt('return', {
               cipherStream: cipherStream,
               decipherStream: decipherStream,
@@ -210,7 +219,7 @@ var Handshake = function Handshake(cryptoManager) {
               pendingBuffers: [].concat((0, _toConsumableArray3.default)(_this._pendingBuffers))
             });
 
-          case 24:
+          case 26:
           case 'end':
             return _context2.stop();
         }

--- a/src/clients/Device.js
+++ b/src/clients/Device.js
@@ -219,6 +219,7 @@ class Device extends EventEmitter {
       });
     } catch (error) {
       this.disconnect(error);
+      throw error;
     }
   };
 

--- a/src/lib/Handshake.js
+++ b/src/lib/Handshake.js
@@ -147,6 +147,10 @@ class Handshake {
       this._onDecipherStreamTimeout(),
     ]);
 
+    if (!handshakeBuffer) {
+      throw new Error('wrong device public keys');
+    }
+
     return {
       cipherStream,
       decipherStream,


### PR DESCRIPTION
The issue now is that handshake errors are logged in 3 places:
1) in Handshake.js on promise catch() , then it rethrows;
https://github.com/Brewskey/spark-protocol/blob/dev/src/lib/Handshake.js#L115-L125
2) in Device.js, on startHandshake -> this.disconnect(); and it rethrows(after current pr)
https://github.com/Brewskey/spark-protocol/blob/dev/src/clients/Device.js#L220-L222 
3) in DeviceServer.js, on _onNewSocketConnection() try-catch..
https://github.com/Brewskey/spark-protocol/blob/dev/src/server/DeviceServer.js#L203-L205

and we `have` to rethrow it in 1) and 2), because in 2) on error invokes this.dissconnect() and in 3) it prevent invoking device.ready();
..so the only place I see where we can reduce logs is: remove logger.error() inside handshake itself.