### PR TITLE
remove Buffer.from(), use deprecated constructor instead

### DIFF
--- a/dist/lib/ChunkingStream.js
+++ b/dist/lib/ChunkingStream.js
@@ -136,7 +136,7 @@ var ChunkingStream = function (_Transform) {
     };
 
     _this._transform = function (chunk, encoding, callback) {
-      var buffer = Buffer.from(chunk);
+      var buffer = new Buffer(chunk);
       if (_this._outgoing) {
         // we should be passed whole messages here.
         // write our length first, then message, then bail.

--- a/src/lib/ChunkingStream.js
+++ b/src/lib/ChunkingStream.js
@@ -123,7 +123,7 @@ class ChunkingStream extends Transform {
     encoding: string,
     callback: Function,
   ) => {
-    const buffer = Buffer.from(chunk);
+    const buffer = new Buffer(chunk);
     if (this._outgoing) {
       // we should be passed whole messages here.
       // write our length first, then message, then bail.


### PR DESCRIPTION
closes https://github.com/Brewskey/spark-server/issues/104