### PR TITLE
Filter releases that have binaries attached.

### DIFF
--- a/dist/scripts/update-firmware-binaries.js
+++ b/dist/scripts/update-firmware-binaries.js
@@ -227,7 +227,7 @@ var downloadAppBinaries = function () {
 }();
 
 (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee3() {
-  var tags, release, downloadedBinaries, settingsBinaries, specificationsResponse, versionResponse, versionText, startIndex, endIndex, data, mapping, ii;
+  var releases, release, downloadedBinaries, settingsBinaries, specificationsResponse, versionResponse, versionText, startIndex, endIndex, data, mapping, ii;
   return _regenerator2.default.wrap(function _callee3$(_context3) {
     while (1) {
       switch (_context3.prev = _context3.next) {
@@ -257,7 +257,7 @@ var downloadAppBinaries = function () {
           }
 
           _context3.next = 9;
-          return githubAPI.repos.getTags({
+          return githubAPI.repos.getReleases({
             owner: GITHUB_USER,
             page: 0,
             perPage: 30,
@@ -265,25 +265,25 @@ var downloadAppBinaries = function () {
           });
 
         case 9:
-          tags = _context3.sent;
+          releases = _context3.sent;
 
-          tags = tags.filter(function (tag
+          releases = releases.filter(function (release
           // Don't use release candidates.. we only need main releases.
           ) {
-            return !tag.name.includes('-rc') && !tag.name.includes('-pi');
+            return !release.tag_name.includes('-rc') && !release.tag_name.includes('-pi') && release.assets.length > 2;
           });
 
-          tags.sort(function (a, b) {
-            if (a.name < b.name) {
+          releases.sort(function (a, b) {
+            if (a.tag_name < b.tag_name) {
               return 1;
             }
-            if (a.name > b.name) {
+            if (a.tag_name > b.tag_name) {
               return -1;
             }
             return 0;
           });
 
-          versionTag = tags[0].name;
+          versionTag = releases[0].tag_name;
 
         case 13:
           _context3.next = 15;

--- a/src/scripts/update-firmware-binaries.js
+++ b/src/scripts/update-firmware-binaries.js
@@ -182,29 +182,30 @@ const downloadAppBinaries = async (): Promise<*> => {
 
   // Download firmware binaries
   if (process.argv.length !== 3) {
-    let tags = await githubAPI.repos.getTags({
+    let releases = await githubAPI.repos.getReleases({
       owner: GITHUB_USER,
       page: 0,
       perPage: 30,
       repo: GITHUB_FIRMWARE_REPOSITORY,
     });
-    tags = tags.filter((tag: Object): boolean =>
+    releases = releases.filter((release: Object): boolean =>
       // Don't use release candidates.. we only need main releases.
-      !tag.name.includes('-rc') &&
-      !tag.name.includes('-pi'),
+      !release.tag_name.includes('-rc') &&
+      !release.tag_name.includes('-pi') &&
+      release.assets.length > 2,
     );
 
-    tags.sort((a: Object, b: Object): number => {
-      if (a.name < b.name) {
+    releases.sort((a: Object, b: Object): number => {
+      if (a.tag_name < b.tag_name) {
         return 1;
       }
-      if (a.name > b.name) {
+      if (a.tag_name > b.tag_name) {
         return -1;
       }
       return 0;
     });
 
-    versionTag = tags[0].name;
+    versionTag = releases[0].tag_name;
   }
 
   const release = await githubAPI.repos.getReleaseByTag({


### PR DESCRIPTION
Latest spark/firmware tag may not necessarily have a release with binaries attached as is the case right now with v0.6.1.