### PR TITLE
remove nullthrow check from response listener in publishAndListenForR…

### DIFF
--- a/dist/lib/EventPublisher.js
+++ b/dist/lib/EventPublisher.js
@@ -49,10 +49,6 @@ var _events = require('events');
 
 var _events2 = _interopRequireDefault(_events);
 
-var _nullthrows = require('nullthrows');
-
-var _nullthrows2 = _interopRequireDefault(_nullthrows);
-
 var _uuid = require('uuid');
 
 var _uuid2 = _interopRequireDefault(_uuid);
@@ -63,27 +59,29 @@ var _settings2 = _interopRequireDefault(_settings);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+/*
+*   Copyright (c) 2015 Particle Industries, Inc.  All rights reserved.
+*
+*   This program is free software; you can redistribute it and/or
+*   modify it under the terms of the GNU Lesser General Public
+*   License as published by the Free Software Foundation, either
+*   version 3 of the License, or (at your option) any later version.
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+*   Lesser General Public License for more details.
+*
+*   You should have received a copy of the GNU Lesser General Public
+*   License along with this program; if not, see <http://www.gnu.org/licenses/>.
+*
+* 
+*
+*/
+
 var getRequestEventName = exports.getRequestEventName = function getRequestEventName(eventName) {
   return eventName + '/request';
-}; /*
-   *   Copyright (c) 2015 Particle Industries, Inc.  All rights reserved.
-   *
-   *   This program is free software; you can redistribute it and/or
-   *   modify it under the terms of the GNU Lesser General Public
-   *   License as published by the Free Software Foundation, either
-   *   version 3 of the License, or (at your option) any later version.
-   *
-   *   This program is distributed in the hope that it will be useful,
-   *   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-   *   Lesser General Public License for more details.
-   *
-   *   You should have received a copy of the GNU Lesser General Public
-   *   License along with this program; if not, see <http://www.gnu.org/licenses/>.
-   *
-   * 
-   *
-   */
+};
 
 var LISTEN_FOR_RESPONSE_TIMEOUT = 15000;
 
@@ -131,7 +129,7 @@ var EventPublisher = function (_EventEmitter) {
                 responseEventName = eventData.name + '/response/' + eventID;
                 return _context.abrupt('return', new _promise2.default(function (resolve, reject) {
                   var responseListener = function responseListener(event) {
-                    return resolve((0, _nullthrows2.default)(event.context));
+                    return resolve(event.context);
                   };
 
                   _this.subscribe(responseEventName, responseListener, {

--- a/src/lib/EventPublisher.js
+++ b/src/lib/EventPublisher.js
@@ -21,7 +21,6 @@
 import type { EventData, ProtocolEvent, PublishOptions } from '../types';
 
 import EventEmitter from 'events';
-import nullthrows from 'nullthrows';
 import uuid from 'uuid';
 import settings from '../settings';
 
@@ -97,7 +96,7 @@ class EventPublisher extends EventEmitter {
         reject: (error: Error) => void,
       ) => {
         const responseListener = (event: ProtocolEvent): void =>
-          resolve(nullthrows(event.context));
+          resolve(event.context);
 
         this.subscribe(responseEventName, responseListener, {
           once: true,


### PR DESCRIPTION
…esponse, since deiviceFunction call results can return null, should fix https://github.com/Brewskey/spark-server/issues/264